### PR TITLE
Patch for node-sass

### DIFF
--- a/lagom/utils.scss
+++ b/lagom/utils.scss
@@ -9,7 +9,7 @@ $base_px: 16 !default;
 */
 @function setUnit($value, $unit) {
 	@if $value {
-		@return #{$value}$unit;
+		@return #{$value}#{$unit};
 	}
 	@return null;
 }
@@ -23,7 +23,7 @@ $base_px: 16 !default;
 */
 @function pxToRem($target_px: null, $context_px: $base_px) {
 	@if $target_px {
- 	  @return setUnit( ($target_px / $context_px),  rem);
+ 	  @return setUnit( ($target_px / $context_px), rem);
  	}
  	@return null;
 }


### PR DESCRIPTION
setUnit "failed" with node-sass 1.1.0 and inserted a space between the value and unit. Worked fine with ruby sass (gem install sass).

**test.scss**

```
@import 'lagom/utils';

.foo {
    border: pxToRem(10) solid black;
}

.bar {
    border: pxToEm(10) solid black;
}

```

$ sass --version
Sass 3.4.21 (Selective Steve)

$ node-sass --version
node-sass   3.4.2   (Wrapper)   [JavaScript]
libsass     3.3.2   (Sass Compiler) [C/C++]

.. and i removed a double-space.
